### PR TITLE
feat(client-examples): MYEN-545 concat returnUrl to enrolUrl

### DIFF
--- a/client/angular-dapp/src/app/login/login.component.ts
+++ b/client/angular-dapp/src/app/login/login.component.ts
@@ -20,7 +20,7 @@ export class LoginComponent {
   errored = false;
   unauthorized = false;
   did: string = undefined;
-  enrolmentURL = environment.ENROLMENT_URL;
+  enrolmentURL = environment.ENROLMENT_URL ? `${environment.ENROLMENT_URL}&returnUrl=${encodeURIComponent(window.location.href)}` : '';
   roles: Role[] = [];
 
   async verifyIdentity() {

--- a/client/react-dapp/src/App.tsx
+++ b/client/react-dapp/src/App.tsx
@@ -83,7 +83,7 @@ function App() {
   )
   
   const enrolmentButton = config.enrolmentUrl && (
-        <a href={config.enrolmentUrl} className="button">
+        <a href={`${config.enrolmentUrl}&returnUrl=${encodeURIComponent(window.location.href)}`} className="button">
           <span>Enrol to test role</span>
         </a>
       )

--- a/client/vue-dapp/src/components/Main.vue
+++ b/client/vue-dapp/src/components/Main.vue
@@ -100,7 +100,7 @@ export default Vue.extend({
       unauthorized: false,
       did: "",
       roles: [],
-      enrolmentUrl: config.enrolmentUrl
+      enrolmentUrl: config.enrolmentUrl ? `${config.enrolmentUrl}&returnUrl=${encodeURIComponent(window.location.href)}` : ''
     };
   },
   methods: {


### PR DESCRIPTION
Adding current URL as `returnUrl` query param when redirecting to enrolment URL